### PR TITLE
add string preprocessing to be cool enough for json

### DIFF
--- a/R/mc_hammer.R
+++ b/R/mc_hammer.R
@@ -12,6 +12,17 @@ mc_hammer <- function(my_quiz, quiz_id, quiz_type = c("MultipleChoiceQuizz", "Si
 
   quiz_type <- match.arg(quiz_type)
 
+  my_quiz <-
+    my_quiz %>%
+    stringr::str_replace("question:", '"question":') %>%
+    stringr::str_replace("answers:", '"answers":') %>%
+    stringr::str_replace("success_message:", '"success_message":') %>%
+    stringr::str_replace_all("text:", '"text":') %>%
+    stringr::str_replace_all("hint:", '"hint":') %>%
+    stringr::str_replace_all("is_correct:", '"is_correct":') %>%
+    stringr::str_replace_all('“', '"') %>%
+    stringr::str_replace_all('”', '"')
+
   quiz_list_test <- jsonlite::fromJSON(my_quiz, simplifyDataFrame = FALSE)
 
   assertthat::assert_that(

--- a/R/mc_hammer.R
+++ b/R/mc_hammer.R
@@ -8,7 +8,11 @@
 #' @export
 #'
 #' @examples
-mc_hammer <- function(my_quiz, quiz_id, quiz_type = c("MultipleChoiceQuizz", "SingleChoiceQuizz")) {
+mc_hammer <- function(
+  my_quiz,
+  quiz_id = paste0(Sys.info()[8], "_", as.numeric(Sys.time())),
+  quiz_type = c("MultipleChoiceQuizz", "SingleChoiceQuizz")
+  ) {
 
   quiz_type <- match.arg(quiz_type)
 


### PR DESCRIPTION
Hi, 
I've added some things to `mc_hammer()` that fixes two things for me. I've filed this pull request if you want to implement this in the official Giulia `{ntft}` fork too.

Specifically, this PR does some string pre processing in `mc_hammer()` that fixes:

- the need to do a the find and replace all to make the json keys strings
- it replaces two possible variations of double quotation marks to `"`

This second point comes from that in my quizes, there was something funny with some quotation marks in my source Rmarkdown files, i.e. sometimes they were recorded in the file as `“` and `”` instead of `"`. When running `mc_hammer()` It caused `mc_hammer()` to return an error because the underlying `jsonlite::fromJSON()`can't deal with such quotation marks.